### PR TITLE
Fix scalafmt formatting on main

### DIFF
--- a/core/src/main/scala/de/thatscalaguy/skunkcrypt/CryptError.scala
+++ b/core/src/main/scala/de/thatscalaguy/skunkcrypt/CryptError.scala
@@ -16,15 +16,12 @@
 
 package de.thatscalaguy.skunkcrypt
 
-/** Errors raised while decrypting a column value. They extend
-  * [[RuntimeException]] so they surface through Skunk's synchronous codec path
-  * and can be caught by consumers.
+/** Errors raised while decrypting a column value. They extend `RuntimeException` so they surface through Skunk's synchronous codec path and can be caught by
+  * consumers.
   */
-sealed abstract class CryptError(message: String, cause: Throwable)
-    extends RuntimeException(message, cause)
+sealed abstract class CryptError(message: String, cause: Throwable) extends RuntimeException(message, cause)
 
-/** The stored value does not match the expected `<iv>.<keyIndex>.<data>` layout
-  * (e.g. legacy plaintext or data written by a different library).
+/** The stored value does not match the expected `<iv>.<keyIndex>.<data>` layout (e.g. legacy plaintext or data written by a different library).
   */
 final class MalformedCiphertext
     extends CryptError(
@@ -32,8 +29,6 @@ final class MalformedCiphertext
       null
     )
 
-/** The value was well-formed but could not be decrypted — an unknown key
-  * index, a wrong key, or a failed GCM authentication tag.
+/** The value was well-formed but could not be decrypted — an unknown key index, a wrong key, or a failed GCM authentication tag.
   */
-final class DecryptionFailure(cause: Throwable)
-    extends CryptError(s"Decryption failed: ${cause.getMessage}", cause)
+final class DecryptionFailure(cause: Throwable) extends CryptError(s"Decryption failed: ${cause.getMessage}", cause)

--- a/core/src/test/scala/de/thatscalaguy/skunkcrypt/CryptCodecsSuite.scala
+++ b/core/src/test/scala/de/thatscalaguy/skunkcrypt/CryptCodecsSuite.scala
@@ -26,7 +26,7 @@ import java.util.UUID
 
 class CryptCodecsSuite extends FunSuite {
 
-  val keyHex = "c0e5c54c2a40c95b40d6e837a9c147d4cd7cadeccc555e679efed48f726a5fef"
+  val keyHex                   = "c0e5c54c2a40c95b40d6e837a9c147d4cd7cadeccc555e679efed48f726a5fef"
   implicit val c: CryptContext =
     CryptContext.keyFromHex(keyHex).fold(e => fail(e), identity)
 
@@ -50,7 +50,7 @@ class CryptCodecsSuite extends FunSuite {
 
   test("key validation: wrong key length is rejected") {
     assert(CryptContext.keyFromHex("ab" * 30).isLeft) // 30 bytes
-    assert(CryptContext.keyFromHex("abc").isLeft)      // odd length
+    assert(CryptContext.keyFromHex("abc").isLeft)     // odd length
   }
 
   test("key validation: empty key list is rejected") {


### PR DESCRIPTION
CI on `main` is red at the *Check headers and formatting* step: scalafmt flags `CryptError.scala` and `CryptCodecsSuite.scala`.

Root cause: both files were added in #25 while still untracked. `.scalafmt.conf` sets `project.git = true`, so scalafmt's git-based file discovery skipped the untracked files — the local `scalafmtCheckAll` passed without ever looking at them. Once merged (and tracked), CI checks them and they fail.

This formats both files and removes a Scaladoc `[[RuntimeException]]` link that couldn't resolve (was emitting a `doc` warning).

Verified locally on Scala 2.13 and 3: `headerCheckAll`, `scalafmtCheckAll`, `scalafmtSbtCheck`, `scalafixAll --check`, `mimaReportBinaryIssues`, `doc`, and the unit suite all pass.